### PR TITLE
We don't have to run EGammaPostReco for 2016 Legacy. And we should us…

### DIFF
--- a/SKFlatMaker/script/CRAB3/RunSKFlatMaker.py
+++ b/SKFlatMaker/script/CRAB3/RunSKFlatMaker.py
@@ -172,15 +172,23 @@ myEleID =  [
 ]
 
 if Is2016:
-  from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
-  setupEgammaPostRecoSeq(process,
-                         runVID=True, #saves CPU time by not needlessly re-running VID
-                         era='2016-Legacy',
-                         eleIDModules=myEleID)
-  #a sequence egammaPostRecoSeq has now been created and should be added to your path, eg process.p=cms.Path(process.egammaPostRecoSeq)
+
+  process.recoTree.electron_IDtoSave = cms.untracked.vstring(
+'cutBasedElectronID-Summer16-80X-V1-veto',
+'cutBasedElectronID-Summer16-80X-V1-loose',
+'cutBasedElectronID-Summer16-80X-V1-medium',
+'cutBasedElectronID-Summer16-80X-V1-tight',
+'mvaEleID-Spring16-GeneralPurpose-V1-wp80',
+'mvaEleID-Spring16-GeneralPurpose-V1-wp90',
+'mvaEleID-Spring16-HZZ-V1-wpLoose',
+'mvaEleID-Spring16-HZZ-V1-wpLoose', ### DUMMY
+'mvaEleID-Spring16-GeneralPurpose-V1-wp80',  ### DUMMY
+'mvaEleID-Spring16-GeneralPurpose-V1-wp90', ### DUMMY
+'mvaEleID-Spring16-HZZ-V1-wpLoose', ### DUMMY
+"heepElectronID-HEEPV70",
+  )
 
   process.p = cms.Path(
-    process.egammaPostRecoSeq *
     process.recoTree
   )
 

--- a/SKFlatMaker/script/PDF/RunSKFlatMaker.py
+++ b/SKFlatMaker/script/PDF/RunSKFlatMaker.py
@@ -172,15 +172,23 @@ myEleID =  [
 ]
 
 if Is2016:
-  from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
-  setupEgammaPostRecoSeq(process,
-                         runVID=True, #saves CPU time by not needlessly re-running VID
-                         era='2016-Legacy',
-                         eleIDModules=myEleID)
-  #a sequence egammaPostRecoSeq has now been created and should be added to your path, eg process.p=cms.Path(process.egammaPostRecoSeq)
+
+  process.recoTree.electron_IDtoSave = cms.untracked.vstring(
+'cutBasedElectronID-Summer16-80X-V1-veto',
+'cutBasedElectronID-Summer16-80X-V1-loose',
+'cutBasedElectronID-Summer16-80X-V1-medium',
+'cutBasedElectronID-Summer16-80X-V1-tight',
+'mvaEleID-Spring16-GeneralPurpose-V1-wp80',
+'mvaEleID-Spring16-GeneralPurpose-V1-wp90',
+'mvaEleID-Spring16-HZZ-V1-wpLoose',
+'mvaEleID-Spring16-HZZ-V1-wpLoose', ### DUMMY
+'mvaEleID-Spring16-GeneralPurpose-V1-wp80',  ### DUMMY
+'mvaEleID-Spring16-GeneralPurpose-V1-wp90', ### DUMMY
+'mvaEleID-Spring16-HZZ-V1-wpLoose', ### DUMMY
+"heepElectronID-HEEPV70",
+  )
 
   process.p = cms.Path(
-    process.egammaPostRecoSeq *
     process.recoTree
   )
 

--- a/SKFlatMaker/test/RunSKFlatMaker.py
+++ b/SKFlatMaker/test/RunSKFlatMaker.py
@@ -172,15 +172,23 @@ myEleID =  [
 ]
 
 if Is2016:
-  from RecoEgamma.EgammaTools.EgammaPostRecoTools import setupEgammaPostRecoSeq
-  setupEgammaPostRecoSeq(process,
-                         runVID=True, #saves CPU time by not needlessly re-running VID
-                         era='2016-Legacy',
-                         eleIDModules=myEleID)
-  #a sequence egammaPostRecoSeq has now been created and should be added to your path, eg process.p=cms.Path(process.egammaPostRecoSeq)
+
+  process.recoTree.electron_IDtoSave = cms.untracked.vstring(
+'cutBasedElectronID-Summer16-80X-V1-veto',
+'cutBasedElectronID-Summer16-80X-V1-loose',
+'cutBasedElectronID-Summer16-80X-V1-medium',
+'cutBasedElectronID-Summer16-80X-V1-tight',
+'mvaEleID-Spring16-GeneralPurpose-V1-wp80',
+'mvaEleID-Spring16-GeneralPurpose-V1-wp90',
+'mvaEleID-Spring16-HZZ-V1-wpLoose',
+'mvaEleID-Spring16-HZZ-V1-wpLoose', ### DUMMY
+'mvaEleID-Spring16-GeneralPurpose-V1-wp80',  ### DUMMY
+'mvaEleID-Spring16-GeneralPurpose-V1-wp90', ### DUMMY
+'mvaEleID-Spring16-HZZ-V1-wpLoose', ### DUMMY
+"heepElectronID-HEEPV70",
+  )
 
   process.p = cms.Path(
-    process.egammaPostRecoSeq *
     process.recoTree
   )
 


### PR DESCRIPTION
In the previous tag, I reran EgammaPostReco to obtain Fall17-94X-**V2** ids for 2016 samples. But from #29 and confirmed by Dalmin, we can just use 80x VIDs which are already saved in MiniAOD. So, we don't have to rerun EgammaPostReco, so I removed it.

Also, I want to explain how the bit is saved for electron POG IDs, and how I updated it for 2016.

First, booleans for electron POG IDs are saved as a bit as follows (DataFormats/MuonReco/interface/Muon.h has the same structure);

**1. Defined what POG IDs to save as a vstring** 

https://github.com/CMSSNU/SKFlatMaker/blob/2a39620275d0bd173a3414f06688fb0d67c19508/SKFlatMaker/python/SKFlatMaker_cfi.py#L36-L49

**2. Loop over this vstring, and put 0 or 1 for each digit**

https://github.com/CMSSNU/SKFlatMaker/blob/2a39620275d0bd173a3414f06688fb0d67c19508/SKFlatMaker/src/SKFlatMaker.cc#L2155-L2164

For example, if an electron has

 "cutBasedElectronID-Fall17-94X-V2-veto" -> Pass
 "cutBasedElectronID-Fall17-94X-V2-loose" -> Pass
 "cutBasedElectronID-Fall17-94X-V2-medium" -> Pass
 "cutBasedElectronID-Fall17-94X-V2-tight" -> Fail
 'mvaEleID-Fall17-iso-V2-wp80' -> Pass
 'mvaEleID-Fall17-iso-V2-wp90' -> Pass
 'mvaEleID-Fall17-iso-V2-wpHZZ' -> Pass
 'mvaEleID-Fall17-iso-V2-wpLoose' -> Pass
 'mvaEleID-Fall17-noIso-V2-wp80' -> Pass
 'mvaEleID-Fall17-noIso-V2-wp90' -> Pass
 'mvaEleID-Fall17-noIso-V2-wpLoose' -> Pass
"heepElectronID-HEEPV70" -> Pass

Then, IDBit in binary number is : **111111110111**

Now, for 2016 Legacy, we want to save 80x VIDs, and I suggest a simple trick;

- Replace 94x ID to 80x if corresponding ID exists
(e.g., "cutBasedElectronID-Fall17-94X-V2-veto" -> 'cutBasedElectronID-Summer16-80X-V1-veto')
- If not, put a dummy ID to fill that digit
(e.g., 'mvaEleID-Fall17-iso-V2-wpLoose' does not exit in 80x. Just put 'mvaEleID-Spring16-HZZ-V1-wpLoose' here)

Then in the analyzer level, we can treat 16 and 17 with a same method.
