### PR TITLE
We need to use 9410 for 2016 and 2017. L1Prefire recipe does not work…

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,14 @@ git cms-merge-topic jedori0228:L1Prefiring_9_4_9__UseFileFileInPath
 # Copy this code
 git clone git@github.com:CMSSNU/SKFlatMaker.git
 cd SKFlatMaker
-git checkout <branch or tag>
+
+#### 1) For a test job or development 
+git checkout master
+git checkout -b <testbranch>
+
+#### 2) For production
+git checkout Run2Legacy_v3 #### use the tag
+
 cd $CMSSW_BASE/src
 
 # Compile
@@ -154,7 +161,14 @@ git cms-addpkg RecoMET/METFilters
 # Copy this code
 git clone git@github.com:CMSSNU/SKFlatMaker.git
 cd SKFlatMaker
-git checkout <branch or tag>
+
+#### 1) For a test job or development 
+git checkout master
+git checkout -b <testbranch>
+
+#### 2) For production
+git checkout Run2Legacy_v3 #### use the tag
+
 cd $CMSSW_BASE/src
 
 # Compile

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Environment
 ```bash
-# Setup for >= CMSSW_9_4_13
+# Setup for >= CMSSW_9_4_10
 export SCRAM_ARCH=slc6_amd64_gcc630
 
 # For machines with CVMFS
@@ -12,8 +12,17 @@ export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
 source $VO_CMS_SW_DIR/cmsset_default.sh
 
 # Make CMSSW directory
-cmsrel CMSSW_9_4_13
-cd CMSSW_9_4_13/src
+
+#### 1) For a test job or developement 
+cmsrel CMSSW_9_4_10
+cd CMSSW_9_4_10/src
+
+#### 2) For production, let's not use the working directory but use new and clean directory
+#### Also, I recommend using lxplus
+scram p -n Run2Legacy_v3__CMSSW_9_4_10 CMSSW CMSSW_9_4_10
+cd Run2Legacy_v3__CMSSW_9_4_10/src
+
+#### Then,
 cmsenv
 git cms-init
 
@@ -22,7 +31,18 @@ git cms-init
 #### https://twiki.cern.ch/twiki/bin/view/CMS/EgammaMiniAODV2#2017_MiniAOD_V2
 ######################
 
-git cms-merge-topic cms-egamma:EgammaPostRecoTools
+git cms-merge-topic cms-egamma:EgammaPostRecoTools_940 #just adds in an extra file to have a setup function to make things easier
+scram b -j4
+
+#############
+#### v2 VID
+#### https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2#Recipe_for_regular_users_formats
+#### The Fall17_94X_V2 ID modules are included by default for CMSSW_10_2_X and higher, for CMSSW_9_4_X you can obtain them through following git cms-merge-topic: 
+#### Both CutBased and MVA
+#############
+
+git cms-merge-topic cms-egamma:EgammaID_949
+scram b -j4
 
 ##########################
 #### MET EE Noise filter
@@ -31,6 +51,7 @@ git cms-merge-topic cms-egamma:EgammaPostRecoTools
 ##########################
 
 git cms-merge-topic cms-met:METFixEE2017_949_v2
+scram b -j4
 
 ###############################
 #### Rerun ecalBadCalibfilter
@@ -38,6 +59,7 @@ git cms-merge-topic cms-met:METFixEE2017_949_v2
 ###############################
 
 git cms-addpkg RecoMET/METFilters
+scram b -j4
 
 #########################
 #### L1Prefire reweight
@@ -46,9 +68,11 @@ git cms-addpkg RecoMET/METFilters
 
 #git cms-merge-topic lathomas:L1Prefiring_9_4_9
 git cms-merge-topic jedori0228:L1Prefiring_9_4_9__UseFileFileInPath
+#### Do not compile here, we need SKFlatMaker cloned
 
-################################################################################################
-################################################################################################
+######################
+#### Now SKFlatMaker
+######################
 
 # Copy this code
 git clone git@github.com:CMSSNU/SKFlatMaker.git
@@ -57,71 +81,11 @@ git checkout <branch or tag>
 cd $CMSSW_BASE/src
 
 # Compile
-scram b -j 8
+scram b -j4
 
 # Setup
 cd $CMSSW_BASE/src/SKFlatMaker
 source setup.sh
-```
-### For the Production
-I recommend you to make a clean working directory when we do the central production.
-
-Also, I recommend using lxplus
-
-```bash
-# scram p -n <directory name> CMSSW <cmssw release>
-# below, assuming we are using tag:Run2Legacy_v3, in cmssw:CMSSW_9_4_13
-export SCRAM_ARCH=slc6_amd64_gcc630
-scram p -n Run2Legacy_v3__CMSSW_9_4_13 CMSSW CMSSW_9_4_13
-cd Run2Legacy_v3__CMSSW_9_4_13/src
-cmsenv
-# crab setup
-source /cvmfs/cms.cern.ch/crab3/crab.sh
-
-###############################################
-# Environmenet setup. Basically same as above
-###############################################
-
-git cms-init
-
-######################
-#### EGamma smearing
-#### https://twiki.cern.ch/twiki/bin/view/CMS/EgammaMiniAODV2#2017_MiniAOD_V2
-######################
-
-git cms-merge-topic cms-egamma:EgammaPostRecoTools
-
-##########################
-#### MET EE Noise filter
-#### https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/1865.html
-#### https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETUncertaintyPrescription#Instructions_for_9_4_X_X_9_for_2
-##########################
-
-git cms-merge-topic cms-met:METFixEE2017_949_v2
-
-###############################
-#### Rerun ecalBadCalibfilter
-#### https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#How_to_run_ecal_BadCalibReducedM
-###############################
-
-git cms-addpkg RecoMET/METFilters
-
-#########################
-#### L1Prefire reweight
-#### https://twiki.cern.ch/twiki/bin/view/CMS/L1ECALPrefiringWeightRecipe
-#########################
-
-#git cms-merge-topic lathomas:L1Prefiring_9_4_9
-git cms-merge-topic jedori0228:L1Prefiring_9_4_9__UseFileFileInPath
-
-# Now SKFlatMaker
-
-git clone git@github.com:CMSSNU/SKFlatMaker.git
-cd SKFlatMaker
-git checkout Run2Legacy_v3 ## This let us use exactly same tag without any modifications..
-source setup.sh
-cd $CMSSW_BASE/src
-scram b -j 8
 
 # Now, submitting crab jobs.
 cd $CMSSW_BASE/src/SKFlatMaker/SKFlatMaker/script/CRAB3
@@ -133,6 +97,7 @@ python MakeCrab.py <txtfilename>
 cd $SKFlatTag/2017/crab_submission_DATA/
 # now, run the submission commands
 ```
+
 ## For 2018
 
 ### Environment
@@ -145,8 +110,17 @@ export VO_CMS_SW_DIR=/cvmfs/cms.cern.ch
 source $VO_CMS_SW_DIR/cmsset_default.sh
 
 # Make CMSSW directory
+
+#### 1) For a test job or developement
 cmsrel CMSSW_10_4_0_patch1
 cd CMSSW_10_4_0_patch1/src
+
+#### 2) For production, let's not use the working directory but use new and clean directory
+#### Also, I recommend using lxplus
+scram p -n Run2Legacy_v3__CMSSW_10_4_0_patch1 CMSSW CMSSW_10_4_0_patch1
+cd Run2Legacy_v3__CMSSW_10_4_0_patch1/src
+
+#### Then,
 cmsenv
 git cms-init
 
@@ -173,8 +147,9 @@ scram b -j 8
 
 git cms-addpkg RecoMET/METFilters
 
-################################################################################################
-################################################################################################
+######################
+#### Now SKFlatMaker
+######################
 
 # Copy this code
 git clone git@github.com:CMSSNU/SKFlatMaker.git
@@ -188,60 +163,6 @@ scram b -j 8
 # Setup
 cd $CMSSW_BASE/src/SKFlatMaker
 source setup.sh
-```
-
-### For the Production
-I recommend you to make a clean working directory when we do the central production.
-
-Also, I recommend using lxplus
-
-```bash
-# scram p -n <directory name> CMSSW <cmssw release>
-# below, assuming we are using tag:Run2Legacy_v3, in cmssw:CMSSW_10_4_0_patch1
-export SCRAM_ARCH=slc6_amd64_gcc700
-scram p -n Run2Legacy_v3__CMSSW_10_4_0_patch1 CMSSW CMSSW_10_4_0_patch1
-cd Run2Legacy_v3__CMSSW_10_4_0_patch1/src
-cmsenv
-# crab setup
-source /cvmfs/cms.cern.ch/crab3/crab.sh
-
-###############################################
-# Environmenet setup. Basically same as above
-###############################################
-
-git cms-init
-
-######################
-#### EGamma smearing
-#### https://twiki.cern.ch/twiki/bin/view/CMS/EgammaMiniAODV2#2018_MiniAOD
-#### https://twiki.cern.ch/twiki/bin/viewauth/CMS/EgammaPostRecoRecipes#2018_Preliminary_Energy_Correcti
-######################
-
-git cms-merge-topic cms-egamma:EgammaPostRecoTools #just adds in an extra file to have a setup function to make things easier
-scram b -j 8
-
-git clone git@github.com:cms-egamma/EgammaAnalysis-ElectronTools.git EgammaAnalysis/ElectronTools/data
-cd EgammaAnalysis/ElectronTools/data
-git checkout ScalesSmearing2018_Dev
-cd -
-git cms-merge-topic cms-egamma:EgammaPostRecoTools_dev
-scram b -j 8
-
-###############################
-#### Rerun ecalBadCalibfilter
-#### https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#How_to_run_ecal_BadCalibReducedM
-###############################
-
-git cms-addpkg RecoMET/METFilters
-
-# Now SKFlatMaker
-
-git clone git@github.com:CMSSNU/SKFlatMaker.git
-cd SKFlatMaker
-git checkout Run2Legacy_v3 ## This let us use exactly same tag without any modifications..
-source setup.sh
-cd $CMSSW_BASE/src
-scram b -j 8
 
 # Now, submitting crab jobs.
 cd $CMSSW_BASE/src/SKFlatMaker/SKFlatMaker/script/CRAB3
@@ -253,8 +174,9 @@ python MakeCrab.py
 # copy them somewhere
 cd $SKFlatTag/2018/crab_submission_DATA/
 # now, run the submission commands
+```
 
-## test runs
+# test runs
 ```bash
 cd $CMSSW_BASE/src/SKFlatMaker/SKFlatMaker/test/
 cmsRun RunSKFlatMaker.py year=2016 sampletype=DATA maxEvents=1000 ## Run 2016 DATA


### PR DESCRIPTION
L1Prefire recipe is merged in CMSSW_9_4_13, but that does not work.

We should use CMSSW_9_4_10 instead, so the recipe must be rolled back.