### PR TITLE
Preparing run2 legacy v4 part2

### DIFF
--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -652,6 +652,12 @@ class SKFlatMaker : public edm::EDAnalyzer
 
   //==== LHE
 
+  vector<double> LHE_Px;
+  vector<double> LHE_Py;
+  vector<double> LHE_Pz;
+  vector<double> LHE_E;
+  vector<double> LHE_Status;
+  vector<double> LHE_ID;
   vector<double> PDFWeights_Scale;
   vector<double> PDFWeights_Error;
   vector<double> PDFWeights_AlphaS;

--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -634,6 +634,18 @@ class SKFlatMaker : public edm::EDAnalyzer
   vector<double> muon_PfNeutralHadronMiniIso;
   vector<double> muon_PfGammaMiniIso;
   vector<double> muon_PFSumPUMiniIso;
+  vector<double> muon_MVA;
+  vector<double> muon_lowptMVA;
+  vector<double> muon_softMVA;
+  vector<double> muon_jetPtRatio;
+  vector<double> muon_jetPtRel;
+  vector<int> muon_simType;
+  vector<int> muon_simExtType;
+  vector<int> muon_simFlavour;
+  vector<int> muon_simHeaviestMotherFlavour;
+  vector<int> muon_simPdgId;
+  vector<int> muon_simMotherPdgId;
+  vector<double> muon_simMatchQuality;
 
   //==== Rochestor correction
   RoccoR rc;

--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -536,6 +536,7 @@ class SKFlatMaker : public edm::EDAnalyzer
   vector<double> electron_RelPFIso_dBeta;
   vector<double> electron_RelPFIso_Rho;
   vector<unsigned int> electron_IDBit;
+  vector<int> electron_IDCutBit;
   vector<double> electron_EnergyUnCorr;
   vector<double> electron_chMiniIso;
   vector<double> electron_nhMiniIso;

--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -657,8 +657,8 @@ class SKFlatMaker : public edm::EDAnalyzer
   vector<double> LHE_Py;
   vector<double> LHE_Pz;
   vector<double> LHE_E;
-  vector<double> LHE_Status;
-  vector<double> LHE_ID;
+  vector<int> LHE_Status;
+  vector<int> LHE_ID;
   vector<double> PDFWeights_Scale;
   vector<double> PDFWeights_Error;
   vector<double> PDFWeights_AlphaS;

--- a/SKFlatMaker/script/varlist_Electron.txt
+++ b/SKFlatMaker/script/varlist_Electron.txt
@@ -59,6 +59,7 @@ double	electron_E55	1
 double	electron_RelPFIso_dBeta	1
 double	electron_RelPFIso_Rho	1
 unsigned int	electron_IDBit	1
+int	electron_IDCutBit	1
 double	electron_EnergyUnCorr	1
 double	electron_chMiniIso	1
 double	electron_nhMiniIso	1

--- a/SKFlatMaker/script/varlist_LHE.txt
+++ b/SKFlatMaker/script/varlist_LHE.txt
@@ -1,3 +1,9 @@
 double	PDFWeights_Scale	1
 double	PDFWeights_Error	1
 double	PDFWeights_AlphaS	1
+double	LHE_Px	1
+double	LHE_Py	1
+double	LHE_Pz	1
+double	LHE_E	1
+double	LHE_Status	1
+double	LHE_ID	1

--- a/SKFlatMaker/script/varlist_LHE.txt
+++ b/SKFlatMaker/script/varlist_LHE.txt
@@ -5,5 +5,5 @@ double	LHE_Px	1
 double	LHE_Py	1
 double	LHE_Pz	1
 double	LHE_E	1
-double	LHE_Status	1
-double	LHE_ID	1
+int	LHE_Status	1
+int	LHE_ID	1

--- a/SKFlatMaker/script/varlist_Muon.txt
+++ b/SKFlatMaker/script/varlist_Muon.txt
@@ -78,3 +78,15 @@ double	muon_PfChargedHadronMiniIso	1
 double	muon_PfNeutralHadronMiniIso	1
 double	muon_PfGammaMiniIso	1
 double	muon_PFSumPUMiniIso	1
+double	muon_MVA	1
+double	muon_lowptMVA	1
+double	muon_softMVA	1
+double	muon_jetPtRatio	1
+double	muon_jetPtRel	1
+int	muon_simType	1
+int	muon_simExtType	1
+int	muon_simFlavour	1
+int	muon_simHeaviestMotherFlavour	1
+int	muon_simPdgId	1
+int	muon_simMotherPdgId	1
+double	muon_simMatchQuality	1

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -492,6 +492,18 @@ void SKFlatMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   muon_PfNeutralHadronMiniIso.clear();
   muon_PfGammaMiniIso.clear();
   muon_PFSumPUMiniIso.clear();
+  muon_MVA.clear();
+  muon_lowptMVA.clear();
+  muon_softMVA.clear();
+  muon_jetPtRatio.clear();
+  muon_jetPtRel.clear();
+  muon_simType.clear();
+  muon_simExtType.clear();
+  muon_simFlavour.clear();
+  muon_simHeaviestMotherFlavour.clear();
+  muon_simPdgId.clear();
+  muon_simMotherPdgId.clear();
+  muon_simMatchQuality.clear();
 
   //==== Jet
   jet_pt.clear();
@@ -1060,6 +1072,18 @@ void SKFlatMaker::beginJob()
     DYTree->Branch("muon_PfNeutralHadronMiniIso", "vector<double>", &muon_PfNeutralHadronMiniIso);
     DYTree->Branch("muon_PfGammaMiniIso", "vector<double>", &muon_PfGammaMiniIso);
     DYTree->Branch("muon_PFSumPUMiniIso", "vector<double>", &muon_PFSumPUMiniIso);
+    DYTree->Branch("muon_MVA", "vector<double>", &muon_MVA);
+    DYTree->Branch("muon_lowptMVA", "vector<double>", &muon_lowptMVA);
+    DYTree->Branch("muon_softMVA", "vector<double>", &muon_softMVA);
+    DYTree->Branch("muon_jetPtRatio", "vector<double>", &muon_jetPtRatio);
+    DYTree->Branch("muon_jetPtRel", "vector<double>", &muon_jetPtRel);
+    DYTree->Branch("muon_simType", "vector<int>", &muon_simType);
+    DYTree->Branch("muon_simExtType", "vector<int>", &muon_simExtType);
+    DYTree->Branch("muon_simFlavour", "vector<int>", &muon_simFlavour);
+    DYTree->Branch("muon_simHeaviestMotherFlavour", "vector<int>", &muon_simHeaviestMotherFlavour);
+    DYTree->Branch("muon_simPdgId", "vector<int>", &muon_simPdgId);
+    DYTree->Branch("muon_simMotherPdgId", "vector<int>", &muon_simMotherPdgId);
+    DYTree->Branch("muon_simMatchQuality", "vector<double>", &muon_simMatchQuality);
 
   }
   
@@ -1816,6 +1840,25 @@ void SKFlatMaker::fillMuons(const edm::Event &iEvent, const edm::EventSetup& iSe
     muon_matchedstations.push_back( imuon.numberOfMatchedStations() ); // -- # of chambers with matched segments -- //
     muon_stationMask.push_back( imuon.stationMask() ); // -- bit map of stations with matched segments -- //
 
+    //==== Muon mva
+    //==== https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideMuonIdRun2#Lepton_MVA
+    muon_MVA.push_back( imuon.mvaValue() );
+    //muon_lowptMVA.push_back( imuon.lowptMvaValue() ); // TODO not supported in CMSSW_10_2_10
+    muon_softMVA.push_back( imuon.softMvaValue() );
+
+    //==== Muon miniiso variable
+    muon_jetPtRatio.push_back( imuon.jetPtRatio() );
+    muon_jetPtRel.push_back( imuon.jetPtRel() );
+
+    //==== Muon sim-matching variable
+    //==== https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideMuonIdRun2#SimHit_Muon_matching_since_CMSSW
+    muon_simType.push_back( imuon.simType() );
+    muon_simExtType.push_back( imuon.simExtType() );
+    muon_simFlavour.push_back( imuon.simFlavour() );
+    muon_simHeaviestMotherFlavour.push_back( imuon.simHeaviestMotherFlavour() );
+    muon_simPdgId.push_back( imuon.simPdgId() );
+    muon_simMotherPdgId.push_back( imuon.simMotherPdgId() );
+    //muon_simMatchQuality.push_back( imuon.simMatchQuality() );  // TODO not supported in CMSSW_10_2_10
 
     //=== store ishighpt to get new ID for 10_4_X : use function copied from https://github.com/cms-sw/cmssw/blob/CMSSW_10_4_X/DataFormats/MuonReco/src/MuonSelectors.cc#L910
 

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -1102,8 +1102,8 @@ void SKFlatMaker::beginJob()
     DYTree->Branch("LHE_Py", "vector<double>", &LHE_Py);
     DYTree->Branch("LHE_Pz", "vector<double>", &LHE_Pz);
     DYTree->Branch("LHE_E", "vector<double>", &LHE_E);
-    DYTree->Branch("LHE_Status", "vector<double>", &LHE_Status);
-    DYTree->Branch("LHE_ID", "vector<double>", &LHE_ID);
+    DYTree->Branch("LHE_Status", "vector<int>", &LHE_Status);
+    DYTree->Branch("LHE_ID", "vector<int>", &LHE_ID);
     DYTree->Branch("PDFWeights_Scale", "vector<double>", &PDFWeights_Scale);
     DYTree->Branch("PDFWeights_Error", "vector<double>", &PDFWeights_Error);
     DYTree->Branch("PDFWeights_AlphaS", "vector<double>", &PDFWeights_AlphaS);

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -190,7 +190,7 @@ bool SKFlatMaker::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx){
       if( expectedNnumberOfMatchedStations(muon) <2 ||
           !(muon.stationMask()==1 || muon.stationMask()==16) ||
           muon.numberOfMatchedRPCLayers()>2
-	  )
+    )
         muMatchedSt = true;
     }
   }
@@ -217,8 +217,8 @@ int  SKFlatMaker::expectedNnumberOfMatchedStations(reco::Muon muon, float minDis
       float edgeY = chamberMatch.edgeY;
       // check we if the trajectory is well within the acceptance
       if(edgeX<0 && fabs(edgeX)>fabs(minDistanceFromEdge) &&
-	 edgeY<0 && fabs(edgeY)>fabs(minDistanceFromEdge))
-	stationMask |= 1<<( (chamberMatch.station()-1)+4*(chamberMatch.detector()-1) );
+   edgeY<0 && fabs(edgeY)>fabs(minDistanceFromEdge))
+  stationMask |= 1<<( (chamberMatch.station()-1)+4*(chamberMatch.detector()-1) );
     }
   unsigned int n = 0;
   for(unsigned int i=0; i<8; ++i)
@@ -299,6 +299,12 @@ void SKFlatMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
 
   //==== LHE
 
+  LHE_Px.clear();
+  LHE_Py.clear();
+  LHE_Pz.clear();
+  LHE_E.clear();
+  LHE_Status.clear();
+  LHE_ID.clear();
   PDFWeights_Scale.clear();
   PDFWeights_Error.clear();
   PDFWeights_AlphaS.clear();
@@ -1089,6 +1095,13 @@ void SKFlatMaker::beginJob()
   
   // -- LHE info -- //
   if( theStoreLHEFlag ){
+
+    DYTree->Branch("LHE_Px", "vector<double>", &LHE_Px);
+    DYTree->Branch("LHE_Py", "vector<double>", &LHE_Py);
+    DYTree->Branch("LHE_Pz", "vector<double>", &LHE_Pz);
+    DYTree->Branch("LHE_E", "vector<double>", &LHE_E);
+    DYTree->Branch("LHE_Status", "vector<double>", &LHE_Status);
+    DYTree->Branch("LHE_ID", "vector<double>", &LHE_ID);
     DYTree->Branch("PDFWeights_Scale", "vector<double>", &PDFWeights_Scale);
     DYTree->Branch("PDFWeights_Error", "vector<double>", &PDFWeights_Error);
     DYTree->Branch("PDFWeights_AlphaS", "vector<double>", &PDFWeights_AlphaS);
@@ -2361,7 +2374,22 @@ void SKFlatMaker::fillLHEInfo(const edm::Event &iEvent)
   Handle<LHEEventProduct> LHEInfo;
   iEvent.getByToken(LHEEventProductToken, LHEInfo);
   if(!LHEInfo.isValid()) return;
-  
+
+  //==== LHE object
+  const lhef::HEPEUP& lheEvent = LHEInfo->hepeup();
+  std::vector<lhef::HEPEUP::FiveVector> lheParticles = lheEvent.PUP;
+  for(size_t idxParticle = 0; idxParticle<lheParticles.size(); ++idxParticle){
+
+    LHE_Px.push_back( lheParticles[idxParticle][0] );
+    LHE_Py.push_back( lheParticles[idxParticle][1] );
+    LHE_Pz.push_back( lheParticles[idxParticle][2] );
+    LHE_E.push_back( lheParticles[idxParticle][3] );
+
+    LHE_Status.push_back( lheEvent.ISTUP[idxParticle] );
+    LHE_ID.push_back( lheEvent.IDUP[idxParticle] );
+
+  }
+
   // -- PDf weights for theoretical uncertainties: scale, PDF replica and alphaS variation -- //
   // -- ref: https://twiki.cern.ch/twiki/bin/viewauth/CMS/LHEReaderCMSSW -- //
   int nWeight = (int)LHEInfo->weights().size();
@@ -2750,16 +2778,16 @@ void SKFlatMaker::fillJet(const edm::Event &iEvent)
       //=== 2016 jet IDs
       //==== https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2016
       if(fabs(eta)>3.0){
-	tightJetID = (NEMF<0.90 && NumNeutralParticles>10 );
-	tightLepVetoJetID = (NEMF<0.90 && NumNeutralParticles>10 );
+  tightJetID = (NEMF<0.90 && NumNeutralParticles>10 );
+  tightLepVetoJetID = (NEMF<0.90 && NumNeutralParticles>10 );
       }
       else if(fabs(eta)>2.7){
-	tightJetID = (NHF<0.98 && NEMF>0.01 && NumNeutralParticles>2);
-	tightLepVetoJetID = (NHF<0.98 && NEMF>0.01 && NumNeutralParticles>2);
+  tightJetID = (NHF<0.98 && NEMF>0.01 && NumNeutralParticles>2);
+  tightLepVetoJetID = (NHF<0.98 && NEMF>0.01 && NumNeutralParticles>2);
       }
       else {
-	tightJetID        = (NHF<0.90 && NEMF<0.90 && NumConst>1) &&            ((fabs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || fabs(eta)>2.4) && fabs(eta)<=2.7;
-	tightLepVetoJetID = (NHF<0.90 && NEMF<0.90 && NumConst>1 && MUF<0.8) && ((fabs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.90) || fabs(eta)>2.4) && fabs(eta)<=2.7;
+  tightJetID        = (NHF<0.90 && NEMF<0.90 && NumConst>1) &&            ((fabs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.99) || fabs(eta)>2.4) && fabs(eta)<=2.7;
+  tightLepVetoJetID = (NHF<0.90 && NEMF<0.90 && NumConst>1 && MUF<0.8) && ((fabs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.90) || fabs(eta)>2.4) && fabs(eta)<=2.7;
       }
     }
     else   if(DataYear==2017){
@@ -2774,28 +2802,28 @@ void SKFlatMaker::fillJet(const edm::Event &iEvent)
         tightLepVetoJetID =  (NEMF>0.02 && NEMF<0.99) && (NumNeutralParticles>2);
       }
       else{
-	tightJetID        = (NHF<0.90 && NEMF<0.90 && NumConst>1) &&            ((fabs(eta)<=2.4 && CHF>0 && CHM>0)              || fabs(eta)>2.4) && fabs(eta)<=2.7;
-	tightLepVetoJetID = (NHF<0.90 && NEMF<0.90 && NumConst>1 && MUF<0.8) && ((fabs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.80) || fabs(eta)>2.4) && fabs(eta)<=2.7;	
+  tightJetID        = (NHF<0.90 && NEMF<0.90 && NumConst>1) &&            ((fabs(eta)<=2.4 && CHF>0 && CHM>0)              || fabs(eta)>2.4) && fabs(eta)<=2.7;
+  tightLepVetoJetID = (NHF<0.90 && NEMF<0.90 && NumConst>1 && MUF<0.8) && ((fabs(eta)<=2.4 && CHF>0 && CHM>0 && CEMF<0.80) || fabs(eta)>2.4) && fabs(eta)<=2.7;  
       }
     }
     else   if(DataYear==2018){
       //=== 2018 jet ID
       //==== https://twiki.cern.ch/twiki/bin/viewauth/CMS/JetID13TeVRun2018
       if(fabs(eta)>3.0){
-	tightJetID = (NEMF<0.90 && NHF>0.2 && NumNeutralParticles>10 );
-	tightLepVetoJetID =  (NEMF<0.90 && NHF>0.2 && NumNeutralParticles>10 );
+  tightJetID = (NEMF<0.90 && NHF>0.2 && NumNeutralParticles>10 );
+  tightLepVetoJetID =  (NEMF<0.90 && NHF>0.2 && NumNeutralParticles>10 );
       }
       else if(fabs(eta)>2.7){
-	tightJetID = ( NEMF>0.02 && NEMF<0.99 && NumNeutralParticles>2);
-	tightLepVetoJetID = ( NEMF>0.02 && NEMF<0.99 && NumNeutralParticles>2);
+  tightJetID = ( NEMF>0.02 && NEMF<0.99 && NumNeutralParticles>2);
+  tightLepVetoJetID = ( NEMF>0.02 && NEMF<0.99 && NumNeutralParticles>2);
       }
       else if(fabs(eta)>2.6){
-	tightJetID = ( CHM>0 && NEMF<0.99 && NHF < 0.9 );
-	tightLepVetoJetID = ( CEMF<0.8 && CHM>0 && NEMF<0.99 && MUF <0.8 && NHF < 0.9 );
+  tightJetID = ( CHM>0 && NEMF<0.99 && NHF < 0.9 );
+  tightLepVetoJetID = ( CEMF<0.8 && CHM>0 && NEMF<0.99 && MUF <0.8 && NHF < 0.9 );
       }
       else{
-	tightJetID = (abs(eta)<=2.6 && CHM>0 && CHF>0 && NumConst>1 && NEMF<0.9 && NHF < 0.9 );
-	tightLepVetoJetID = (abs(eta)<=2.6 && CEMF<0.8 && CHM>0 && CHF>0 && NumConst>1 && NEMF<0.9 && MUF <0.8 && NHF < 0.9 );	  
+  tightJetID = (abs(eta)<=2.6 && CHM>0 && CHF>0 && NumConst>1 && NEMF<0.9 && NHF < 0.9 );
+  tightLepVetoJetID = (abs(eta)<=2.6 && CEMF<0.8 && CHM>0 && CHF>0 && NumConst>1 && NEMF<0.9 && MUF <0.8 && NHF < 0.9 );    
       }
     }
     else{
@@ -3097,7 +3125,7 @@ void SKFlatMaker::fillFatJet(const edm::Event &iEvent)
       //=== 2016 jet IDs                                                                                                                                                                                    
       //==== https://twiki.cern.ch/twiki/bin/view/CMS/JetID13TeVRun2016                                                                                                                                     
       if(fabs(eta)>2.7){
-	//Note that the jet ID requirements for |eta|>2.7 are not recommended for PUPPI jets (see e.g. https://indico.cern.ch/event/578287/contributions/2347317/).
+  //Note that the jet ID requirements for |eta|>2.7 are not recommended for PUPPI jets (see e.g. https://indico.cern.ch/event/578287/contributions/2347317/).
 
         tightJetID = false;
         tightLepVetoJetID = false;

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -404,6 +404,7 @@ void SKFlatMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   electron_RelPFIso_dBeta.clear();
   electron_RelPFIso_Rho.clear();
   electron_IDBit.clear();
+  electron_IDCutBit.clear();
   electron_EnergyUnCorr.clear();
   electron_chMiniIso.clear();
   electron_nhMiniIso.clear();
@@ -981,6 +982,7 @@ void SKFlatMaker::beginJob()
     DYTree->Branch("electron_RelPFIso_dBeta", "vector<double>", &electron_RelPFIso_dBeta);
     DYTree->Branch("electron_RelPFIso_Rho", "vector<double>", &electron_RelPFIso_Rho);
     DYTree->Branch("electron_IDBit", "vector<unsigned int>", &electron_IDBit);
+    DYTree->Branch("electron_IDCutBit", "vector<int>", &electron_IDCutBit);
     DYTree->Branch("electron_EnergyUnCorr", "vector<double>", &electron_EnergyUnCorr);
     DYTree->Branch("electron_chMiniIso", "vector<double>", &electron_chMiniIso);
     DYTree->Branch("electron_nhMiniIso", "vector<double>", &electron_nhMiniIso);
@@ -2301,6 +2303,14 @@ el->deltaEtaSuperClusterTrackAtVtx() - el->superCluster()->eta() + el->superClus
       else{
         IDBit &= ~(1 << it_ID);
       }
+
+      //==== bits for each cuts
+      //==== https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideCMSPhysicsObjectSchoolAACHEN2019EGamma, Exercise 2
+      int this_idcutbid = 0;
+      if( el->hasUserInt(electron_IDtoSave.at(it_ID)) ){
+        this_idcutbid = el->userInt(electron_IDtoSave.at(it_ID));
+      }
+      electron_IDCutBit.push_back( this_idcutbid );
     }
     electron_IDBit.push_back( IDBit );
 /*

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -2306,7 +2306,7 @@ el->deltaEtaSuperClusterTrackAtVtx() - el->superCluster()->eta() + el->superClus
 
       //==== bits for each cuts
       //==== https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideCMSPhysicsObjectSchoolAACHEN2019EGamma, Exercise 2
-      int this_idcutbid = 0;
+      int this_idcutbid = -1;
       if( el->hasUserInt(electron_IDtoSave.at(it_ID)) ){
         this_idcutbid = el->userInt(electron_IDtoSave.at(it_ID));
       }


### PR DESCRIPTION
- Muon MVA variables added : https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideMuonIdRun2#Lepton_MVA
- Muon miniiso variables added; muon_jetPtRatio and muon_jetPtRel. No function available for electrons though.. We should calculate them ourselves later, but saving this will be helpful for the cross check between POG and us.
- Sim-matching variables added : https://twiki.cern.ch/twiki/bin/viewauth/CMS/SWGuideMuonIdRun2#SimHit_Muon_matching_since_CMSSW;