### PR TITLE
fix config.General.requestName due to lenght limit

### DIFF
--- a/SKFlatMaker/script/CRAB3/MakeCrab.py
+++ b/SKFlatMaker/script/CRAB3/MakeCrab.py
@@ -67,6 +67,15 @@ for line in lines:
   
   sample = samplePDs[1]
   confs = samplePDs[2]
+
+  #### get extension info
+  #### _ext1-v2
+  extension = ''
+  for w in range(0,len(confs)):
+    if confs[w:w+4]=='_ext':
+      extension = confs[w:]
+      break
+
   cmd = 'crab submit -c SubmitCrab__'+sample+'__'+confs+'.py'
 
   #### AD-HOC for 2018 periodD, which has different GT
@@ -122,7 +131,10 @@ for line in lines:
 
   for sk_line in sk_lines:
     if "config.General.requestName" in sk_line:
-      out.write("config.General.requestName = '"+sample+"__"+confs+"'\n")
+      if isData:
+        out.write("config.General.requestName = '"+sample+"__"+confs+"'\n")
+      else:
+        out.write("config.General.requestName = '"+sample+extension+"'\n")
     elif "config.JobType.pyCfgParams" in sk_line:
       out.write("config.JobType.pyCfgParams = "+ArgsListString+"\n")
     elif "config.Data.inputDataset" in sk_line:


### PR DESCRIPTION
config.General.requestName cannot exceed 100 characters.
For MC, I added campaign (e.g., RunIISummer16MiniAODv3-PUMoriond17_94X_mcRun2_asymptotic_v3_ext1-v2) in the requestName to distinguish extensions (duplicated requestName cannot be used in the same directory), but it makes it longer than 100 characters.

So I fixed it so that we only add '_ext1-v2' in the request name if the input sample is an extension.