### PR TITLE
replacing getUsernameFromSiteDB

### DIFF
--- a/SKFlatMaker/script/CRAB3/MakeCrab.py
+++ b/SKFlatMaker/script/CRAB3/MakeCrab.py
@@ -184,7 +184,7 @@ for line in lines:
         out.write("config.Data.outputDatasetTag = 'SKFlat_"+SKFlatTag+"'\n")
 
     elif 'config.Data.outLFNDirBase' in sk_line:
-      out.write("config.Data.outLFNDirBase = '/store/user/%s/SKFlat/"+year+"/' % (os.environ['SiteUserName'])\n")
+      out.write("config.Data.outLFNDirBase = '/store/user/%s/SKFlat/"+year+"/' % (getUsername())\n")
 
     elif 'config.Site.storageSite' in sk_line:
       #if isPrivateMC:

--- a/SKFlatMaker/script/CRAB3/MakeCrab.py
+++ b/SKFlatMaker/script/CRAB3/MakeCrab.py
@@ -184,7 +184,7 @@ for line in lines:
         out.write("config.Data.outputDatasetTag = 'SKFlat_"+SKFlatTag+"'\n")
 
     elif 'config.Data.outLFNDirBase' in sk_line:
-      out.write("config.Data.outLFNDirBase = '/store/user/%s/SKFlat/"+year+"/' % (getUsernameFromSiteDB())\n")
+      out.write("config.Data.outLFNDirBase = '/store/user/%s/SKFlat/"+year+"/' % (os.environ['SiteUserName'])\n")
 
     elif 'config.Site.storageSite' in sk_line:
       #if isPrivateMC:

--- a/SKFlatMaker/script/CRAB3/skeleton/SubmitCrab.py
+++ b/SKFlatMaker/script/CRAB3/skeleton/SubmitCrab.py
@@ -19,7 +19,7 @@ config.Data.inputDataset = '/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythi
 
 config.Data.splitting = 'FileBased' ## EDIT
 config.Data.unitsPerJob = 1
-config.Data.outLFNDirBase = '/store/user/%s/SKFlat/' % (getUsernameFromSiteDB())
+config.Data.outLFNDirBase = '/store/user/%s/SKFlat/' % (os.environ['SiteUserName'])
 config.Data.publication = False
 config.Data.outputDatasetTag = 'SKFlatMaker_2017_v1'
 

--- a/SKFlatMaker/script/CRAB3/skeleton/SubmitCrab.py
+++ b/SKFlatMaker/script/CRAB3/skeleton/SubmitCrab.py
@@ -1,5 +1,4 @@
-from CRABClient.UserUtilities import config, getUsernameFromSiteDB
-import os
+from CRABClient.UserUtilities import config, getUsername
 
 config = config()
 
@@ -20,7 +19,7 @@ config.Data.inputDataset = '/DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythi
 
 config.Data.splitting = 'FileBased' ## EDIT
 config.Data.unitsPerJob = 1
-config.Data.outLFNDirBase = '/store/user/%s/SKFlat/' % (os.environ['SiteUserName'])
+config.Data.outLFNDirBase = '/store/user/%s/SKFlat/' % (getUsername())
 config.Data.publication = False
 config.Data.outputDatasetTag = 'SKFlatMaker_2017_v1'
 

--- a/SKFlatMaker/script/CRAB3/skeleton/SubmitCrab.py
+++ b/SKFlatMaker/script/CRAB3/skeleton/SubmitCrab.py
@@ -1,4 +1,5 @@
 from CRABClient.UserUtilities import config, getUsernameFromSiteDB
+import os
 
 config = config()
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 export SKFlatTag=Run2Legacy_v4
 export SKFlatWD=$CMSSW_BASE/src/SKFlatMaker/
-export SiteUserName=$USER

--- a/setup.sh
+++ b/setup.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 export SKFlatTag=Run2Legacy_v4
 export SKFlatWD=$CMSSW_BASE/src/SKFlatMaker/
+export SiteUserName=$USER


### PR DESCRIPTION
It seems to me that getUsernameFromSiteDB is not working anymore [1].

I am replacing it to use $SiteUserName which is set from `setup.sh`.

By default, it is set to $USER of your current working machine.

If this is not same as the username of the site where you are sending your crab output
(e.g., if you are sending it to T2_KR_KNU, your knu account name), please modify `setup.sh`.

[1] : https://hypernews.cern.ch/HyperNews/CMS/get/computing-tools/5576/2/2/1/2/1/1/2.html
