### PR TITLE
Fix MVA ver. mismatch btw. boolean & MVA values

### DIFF
--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -2048,8 +2048,8 @@ void SKFlatMaker::fillElectrons(const edm::Event &iEvent, const edm::EventSetup&
   for(int i=0; i< (int)ElecHandle->size(); i++){
     const auto el = ElecHandle->ptrAt(i);
     
-    electron_MVAIso.push_back( el -> userFloat("ElectronMVAEstimatorRun2Fall17IsoV1Values") );
-    electron_MVANoIso.push_back( el -> userFloat("ElectronMVAEstimatorRun2Fall17NoIsoV1Values") );
+    electron_MVAIso.push_back( el -> userFloat("ElectronMVAEstimatorRun2Fall17IsoV2Values") );
+    electron_MVANoIso.push_back( el -> userFloat("ElectronMVAEstimatorRun2Fall17NoIsoV2Values") );
 
     if(el->hasUserFloat("ecalTrkEnergyPostCorr")){
 


### PR DESCRIPTION
MVA version of electron ID is V2, whereas stored discriminant is V1. Changed them for consistent usage.
V2 is better recommended than V1, as ROC performance is much better. 
This is because V1 was trained with old PU scenario assumed before experiment, which was far different from actual PU scenarios in data.