### PR TITLE
Remove IsPrivate option

### DIFF
--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -215,7 +215,9 @@ class SKFlatMaker : public edm::EDAnalyzer
   edm::EDGetTokenT< std::vector<pat::MET> >             MetToken;
 
   edm::EDGetTokenT< LHEEventProduct >               LHEEventProductToken;
+  edm::EDGetTokenT< LHEEventProduct >               LHEEventProductSourceToken;
   edm::EDGetTokenT< LHERunInfoProduct >             LHERunInfoProductToken;
+  edm::EDGetTokenT< LHERunInfoProduct >             LHERunInfoProductSourceToken;
   edm::EDGetTokenT< reco::GenParticleCollection>    mcLabel_;
 
   edm::EDGetTokenT< edm::TriggerResults >          METFilterResultsToken_PAT;

--- a/SKFlatMaker/script/CRAB3/MakeCrab.py
+++ b/SKFlatMaker/script/CRAB3/MakeCrab.py
@@ -30,19 +30,12 @@ lines = open(txtfilename).readlines()
 
 str_sample = "DATA"
 isData = False
-isPrivateMC = False
 if ("DATA" in txtfilename) or ("Data" in txtfilename) or ("data" in txtfilename):
   str_sample = "DATA"
   isData = True
-  isPrivateMC = False
 else:
   str_sample = "MC"
   isData = False
-  isPrivateMC = False
-if ("Private" in txtfilename) or ("private" in txtfilename):
-  str_sample = "PrivateMC"
-  isData = False
-  isPrivateMC = True
 
 base_dir = SKFlatTag+'/'+era+'/crab_submission_'+str_sample+'/'
 
@@ -119,7 +112,7 @@ for line in lines:
       out.write("config.JobType.pyCfgParams = "+ArgsListString+"\n")
     elif "config.Data.inputDataset" in sk_line:
       out.write("config.Data.inputDataset = '"+dasname+"'\n")
-      if isPrivateMC:
+      if dasname.split("/")[3]=="USER":
         out.write("config.Data.inputDBS = 'phys03'\n")
         out.write("config.Data.ignoreLocality = True\n")
         out.write("config.Site.whitelist = ['T2*']\n")

--- a/SKFlatMaker/script/Weight/getLog.py
+++ b/SKFlatMaker/script/Weight/getLog.py
@@ -1,6 +1,6 @@
 import os,sys,argparse
 
-def getLog(dasname,era=None,isPrivate=False,overwrite=False,fileindex=0):
+def getLog(dasname,era=None,overwrite=False,fileindex=0):
   if dasname.count('/')!=3:
     print "Wrong DAS name format"
     return False
@@ -39,14 +39,16 @@ def getLog(dasname,era=None,isPrivate=False,overwrite=False,fileindex=0):
   SKFlatWD = os.environ['SKFlatWD']
 
   dascmd = 'dasgoclient --limit=10 --query="file dataset='+dasname+'"'
-  if isPrivate:
-    dascmd = 'dasgoclient --limit=10 --query="file dataset='+dasname+' instance=prod/phys03"'
   print dascmd
-
   filepaths=os.popen(dascmd).readlines()
   if len(filepaths)==0:
-    print "No file for : "+dasname
-    return False
+    print "Try instance=prod/phys03"
+    dascmd = 'dasgoclient --limit=10 --query="file dataset='+dasname+' instance=prod/phys03"'
+    print dascmd
+    filepaths=os.popen(dascmd).readlines()
+    if len(filepaths)==0:
+      print "No file for : "+dasname
+      return False
 
   filepath = filepaths[fileindex].replace('/xrootd','').strip('\n')
   filepath = 'root://cms-xrd-global.cern.ch/'+filepath
@@ -57,10 +59,7 @@ def getLog(dasname,era=None,isPrivate=False,overwrite=False,fileindex=0):
   if os.path.isfile(weightmap):
     cmd = cmd+' weightmap='+weightmap
 
-  if isPrivate:
-    cmd = cmd+' sampletype=PrivateMC'
-  else:
-    cmd = cmd+' sampletype=MC'
+  cmd = cmd+' sampletype=MC'
 
   cmd = cmd+' era='+era
   
@@ -99,7 +98,7 @@ if __name__=="__main__":
         if line.count('/')!=3:
           continue
         for i in range(3):
-          if getLog(line,era=era,isPrivate=("Private" in arg),overwrite=args.force,fileindex=i)!=-1:
+          if getLog(line,era=era,overwrite=args.force,fileindex=i)!=-1:
             break;
 
     elif arg.count('/')==3:

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -42,7 +42,9 @@ genFatJetToken                      ( consumes< reco::GenJetCollection >        
 MetToken                            ( consumes< std::vector<pat::MET> >                     (iConfig.getParameter<edm::InputTag>("MET")) ),
 
 LHEEventProductToken                ( consumes< LHEEventProduct >                           (iConfig.getUntrackedParameter<edm::InputTag>("LHEEventProduct")) ),
+LHEEventProductSourceToken          ( consumes< LHEEventProduct >                           (edm::InputTag("source")) ),
 LHERunInfoProductToken              ( consumes< LHERunInfoProduct,edm::InRun >              (iConfig.getUntrackedParameter<edm::InputTag>("LHERunInfoProduct")) ),
+LHERunInfoProductSourceToken        ( consumes< LHERunInfoProduct,edm::InRun >              (edm::InputTag("source")) ),
 mcLabel_                            ( consumes< reco::GenParticleCollection>                (iConfig.getUntrackedParameter<edm::InputTag>("GenParticle"))  ),
 
 // -- MET Filter tokens -- //
@@ -2463,6 +2465,7 @@ void SKFlatMaker::fillLHEInfo(const edm::Event &iEvent)
 {
   Handle<LHEEventProduct> LHEInfo;
   iEvent.getByToken(LHEEventProductToken, LHEInfo);
+  if(!LHEInfo.isValid()) iEvent.getByToken(LHEEventProductSourceToken, LHEInfo);
   if(!LHEInfo.isValid()) return;
 
   //==== LHE object
@@ -3373,6 +3376,7 @@ void SKFlatMaker::endRun(const Run & iRun, const EventSetup & iSetup)
     // -- ref: https://twiki.cern.ch/twiki/bin/viewauth/CMS/LHEReaderCMSSW#Retrieving_the_weights -- //
     edm::Handle<LHERunInfoProduct> LHERunInfo;
     iRun.getByToken(LHERunInfoProductToken, LHERunInfo);
+    if(!LHERunInfo.isValid()) iRun.getByToken(LHERunInfoProductSourceToken, LHERunInfo);
     if(!LHERunInfo.isValid()) return;
 
     cout << "[SKFlatMaker::endRun] ##### Information about PDF weights #####" << endl;

--- a/SKFlatMaker/test/RunSKFlatMaker.py
+++ b/SKFlatMaker/test/RunSKFlatMaker.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 
 from FWCore.ParameterSet.VarParsing import VarParsing
 options = VarParsing ('python')
-options.register('sampletype', "DATA", VarParsing.multiplicity.singleton, VarParsing.varType.string, "sampletype: DATA/MC/PrivateMC")
+options.register('sampletype', "DATA", VarParsing.multiplicity.singleton, VarParsing.varType.string, "sampletype: DATA/MC")
 options.register('weightmap', "", VarParsing.multiplicity.singleton, VarParsing.varType.string, "weightmap file path or string: Scale[1,9],PDF[1001,1100],AlphaS[1101,1102],AlphaSScale[1.5,1.5]")
 options.register('era',-1, VarParsing.multiplicity.singleton, VarParsing.varType.string, "era: Which era? 2016preVFP, 2016postVFP, 2017, 2018")
 options.register('year',-1, VarParsing.multiplicity.singleton, VarParsing.varType.string, "Deprecated. Use 'era'")
@@ -38,9 +38,6 @@ if "data" in options.sampletype.lower():
   isMC = False
 if "mc" in options.sampletype.lower():
   isMC = True
-isPrivateSample = False
-if "private" in options.sampletype.lower():
-  isPrivateSample = True
 
 if len(options.inputFiles)==0:
   if Is2016preVFP:
@@ -116,7 +113,6 @@ elif Is2018:
 print 'GT_MC = '+GT_MC
 print 'GT_DATA = '+GT_DATA
 print 'isMC = '+str(isMC)
-print 'isPrivateSample = '+str(isPrivateSample)
 print 'era = '+str(options.era)
 for key in weightmap:
   if len(weightmap[key])>5:
@@ -189,10 +185,6 @@ for key in weightmap:
     setattr(process.recoTree,"weight_"+key,cms.untracked.vdouble(weightmap[key]))
   else:
     setattr(process.recoTree,"weight_"+key,cms.untracked.vint32(weightmap[key]))
-
-if isPrivateSample:
-  process.recoTree.LHEEventProduct = cms.untracked.InputTag("source")
-  process.recoTree.LHERunInfoProduct = cms.untracked.InputTag("source")
 
 process.recoTree.rho = cms.untracked.InputTag("fixedGridRhoFastjetAll")
 process.recoTree.conversionsInputTag = cms.untracked.InputTag("reducedEgamma:reducedConversions") # -- miniAOD -- #


### PR DESCRIPTION
*IsPrivate* option is used to treat the private sample properly in two aspects, but it can be done by code automatically.

1. Get file list from the database
  See *SKFlatMaker/script/CRAB3/MakeCrab.py*, *SKFlatMaker/script/Weight/getLog.py*
  We should use *prod/phys03* for the private samples. Now whether it is a private sample or not is checked based on its DAS name (private samples ends with "/USER") or just using both of *prod/global* (default) and *prod/phys03*. So, users don't need to set *IsPrivate* flag.

1. Get LHE information if external LHE source is used 
  See *SKFlatMaker/test/RunSKFlatMaker.py*, *SKFlatMaker/interface/SKFlatMaker.h*, *SKFlatMaker/src/SKFlatMaker.cc*  
  This is not actually for the private samples. But I guess WR samples were generated with external LHE source, so Jaesung use *IsPrivate* flag also for this. I changed *SKFlatMaker.cc* so that it checks LHEProducer first and then external LHE source. So, users don't need to set *IsPrivate* flag.

