### PR TITLE
update parseLog.py for PSSyst

### DIFF
--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -71,6 +71,7 @@
 ////////////////////////////
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h" // -- LHE info like PDF
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h" // -- ??
+#include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoHeader.h" // -- Pythia weight names
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h" // -- 
 #include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h" // -- ???
@@ -182,6 +183,7 @@ class SKFlatMaker : public edm::EDAnalyzer
   virtual void endJob() ;
   virtual void beginRun(const edm::Run &, const edm::EventSetup & );
   virtual void endRun(const edm::Run &, const edm::EventSetup & );
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup & );
   
   virtual void fillPrimaryVertex(const edm::Event &iEvent);  // fill primary vertex information
   virtual void fillMET(const edm::Event &iEvent);            // fill MET information
@@ -196,6 +198,7 @@ class SKFlatMaker : public edm::EDAnalyzer
 
   int DataYear;
   int theDebugLevel;                   // 0 no prints, 1 some, 2 lots
+  bool printGenWeightNames=true;       //PSSyst names
   std::string processName;
   std::string theElectronID;
   
@@ -236,6 +239,7 @@ class SKFlatMaker : public edm::EDAnalyzer
   edm::EDGetTokenT< reco::VertexCollection >             PrimaryVertexToken;
   edm::EDGetTokenT< edm::View<reco::Track> >             TrackToken;
   edm::EDGetTokenT< std::vector< PileupSummaryInfo > >   PileUpInfoToken;
+  edm::EDGetTokenT< GenLumiInfoHeader >                  GenLumiInfoHeaderToken;
 
   edm::Handle<edm::TriggerResults> METFilterResults;
 

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -65,7 +65,8 @@ GenEventInfoToken                   ( consumes< GenEventInfoProduct >           
 BeamSpotToken                       ( consumes< reco::BeamSpot >                            (iConfig.getUntrackedParameter<edm::InputTag>("BeamSpot")) ),
 PrimaryVertexToken                  ( consumes< reco::VertexCollection >                    (iConfig.getUntrackedParameter<edm::InputTag>("PrimaryVertex")) ),
 TrackToken                          ( consumes< edm::View<reco::Track> >                    (iConfig.getUntrackedParameter<edm::InputTag>("Track")) ),
-PileUpInfoToken                     ( consumes< std::vector< PileupSummaryInfo > >          (iConfig.getUntrackedParameter<edm::InputTag>("PileUpInfo")) )
+PileUpInfoToken                     ( consumes< std::vector< PileupSummaryInfo > >          (iConfig.getUntrackedParameter<edm::InputTag>("PileUpInfo")) ),
+GenLumiInfoHeaderToken              ( consumes< GenLumiInfoHeader,edm::InLumi >             (edm::InputTag("generator")) )
 {
 
   DataYear                          = iConfig.getUntrackedParameter<int>("DataYear");
@@ -3401,7 +3402,18 @@ void SKFlatMaker::endRun(const Run & iRun, const EventSetup & iSetup)
     }
     cout << "[SKFlatMaker::endRun] ##### End of information about PDF weights #####" << endl;
   }
-
+}
+void SKFlatMaker::beginLuminosityBlock(const edm::LuminosityBlock & iLumi, const EventSetup & iSetup){
+  if(printGenWeightNames){
+    edm::Handle<GenLumiInfoHeader> genLumiInfoHeader;
+    iLumi.getByToken(GenLumiInfoHeaderToken, genLumiInfoHeader);
+    if(genLumiInfoHeader.isValid()){
+      for(unsigned int i=0,n=genLumiInfoHeader->weightNames().size();i<n;i++){
+	std::cout << "[SKFlatMaker::beginLuminosityBlock] <weight> id="<<i<<" name='"<<genLumiInfoHeader->weightNames().at(i)<<"' </weight>"<<std::endl;
+      }
+    }
+    printGenWeightNames=false;
+  }
 }
 
 template<class T>


### PR DESCRIPTION
Related to #64 
There are 44 variations in PSSyst but I think ISR up/down and FSR up/down variation are enough for most samples. If you want to test other variations for specific samples, let me know before v3 production.
* Print Generator weight names in `SKFlatMaker::beginLuminosityBlock` function. (cf. LHE weight names are printed in `SKFlatMaker::endRun`)
* *parseLog.py* will pick up the weight indices of ISR up/down and FSR up/down. It should be [4,5,26,27] for central UL samples.