### PR TITLE
using existing JEC jets for the bjet regression; fix bugs

### DIFF
--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -412,10 +412,10 @@ class SKFlatMaker : public edm::EDAnalyzer
   vector<float> jet_JECFull;
   vector<int> jet_GenHFHadronMatcher_flavour;
   vector<int> jet_GenHFHadronMatcher_origin;
-  vector<float> jet_bjetNN_corr;
-  vector<float> jet_bjetNN_res;
-  vector<float> jet_cjetNN_corr;
-  vector<float> jet_cjetNN_res;
+  vector<float> jet_bJetNN_corr;
+  vector<float> jet_bJetNN_res;
+  vector<float> jet_cJetNN_corr;
+  vector<float> jet_cJetNN_res;
 
   //==== JEC
   JetCorrectionUncertainty *jet_jecUnc;

--- a/SKFlatMaker/python/BJetEnergyCorr_cff.py
+++ b/SKFlatMaker/python/BJetEnergyCorr_cff.py
@@ -1,32 +1,16 @@
-from  PhysicsTools.PatAlgos.recoLayer0.jetCorrFactors_cfi import *
-jetCorrFactors = patJetCorrFactors.clone(
-    src='slimmedJets',
-    levels = cms.vstring(
-        'L1FastJet',
-        'L2Relative',
-        'L3Absolute',
-        'L2L3Residual'),
-    primaryVertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-)
-
-from  PhysicsTools.PatAlgos.producersLayer1.jetUpdater_cfi import *
-updatedJets = updatedPatJets.clone(
-    addBTagInfo = False,
-    jetSource = 'slimmedJets',
-    jetCorrFactorsSource=cms.VInputTag(cms.InputTag("jetCorrFactors") ),
-)
+import FWCore.ParameterSet.Config as cms
 
 bJetVars = cms.EDProducer(
     "JetRegressionVarProducer",
     pvsrc = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    src = cms.InputTag("updatedJets"),
+    src = cms.InputTag("updatedPatJetsUpdatedJECslimmedJets"),
     svsrc = cms.InputTag("slimmedSecondaryVertices"),
     gpsrc = cms.InputTag("prunedGenParticles"),
 )
 
 updatedJetsWithUserData = cms.EDProducer(
     "PATJetUserDataEmbedder",
-    src = cms.InputTag("updatedJets"),
+    src = cms.InputTag("updatedPatJetsUpdatedJECslimmedJets"),
     userFloats = cms.PSet(
         leadTrackPt = cms.InputTag("bJetVars:leadTrackPt"),
         leptonPtRel = cms.InputTag("bJetVars:leptonPtRel"),
@@ -48,13 +32,6 @@ updatedJetsWithUserData = cms.EDProducer(
         vtxNtrk = cms.InputTag("bJetVars:vtxNtrk"),
         leptonPdgId = cms.InputTag("bJetVars:leptonPdgId"),
     ),
-)
-
-jetUpdaterSeq = cms.Sequence(
-    jetCorrFactors
-    + updatedJets
-    + bJetVars
-    + updatedJetsWithUserData
 )
 
 bJetNN = cms.EDProducer(
@@ -161,12 +138,9 @@ name = cms.string("JetRegNN"),
     singleThreadPool = cms.string("no_threads"),
 )#cjetNN
 
-correctionSeq = cms.Sequence(
-    bJetNN
-    + cJetNN
-)
-
 bJetCorrSeq = cms.Sequence(
-    jetUpdaterSeq
-    + correctionSeq
+    bJetVars
+    + updatedJetsWithUserData
+    + bJetNN
+    + cJetNN
 )

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -536,10 +536,10 @@ void SKFlatMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   jet_JECFull.clear();
   jet_GenHFHadronMatcher_flavour.clear();
   jet_GenHFHadronMatcher_origin.clear();
-  jet_bjetNN_corr.clear();
-  jet_bjetNN_res.clear();
-  jet_cjetNN_corr.clear();
-  jet_cjetNN_res.clear();
+  jet_bJetNN_corr.clear();
+  jet_bJetNN_res.clear();
+  jet_cJetNN_corr.clear();
+  jet_cJetNN_res.clear();
   
 
   //==== FatJet
@@ -859,10 +859,10 @@ void SKFlatMaker::beginJob()
     DYTree->Branch("jet_JECFull", "vector<float>", &jet_JECFull);
     DYTree->Branch("jet_GenHFHadronMatcher_flavour", "vector<int>", &jet_GenHFHadronMatcher_flavour);
     DYTree->Branch("jet_GenHFHadronMatcher_origin", "vector<int>", &jet_GenHFHadronMatcher_origin);
-    DYTree->Branch("jet_bJetNN_corr", "vector<float>", &jet_bjetNN_corr);
-    DYTree->Branch("jet_bJetNN_res", "vector<float>", &jet_bjetNN_res);
-    DYTree->Branch("jet_cJetNN_corr", "vector<float>", &jet_cjetNN_corr);
-    DYTree->Branch("jet_cJetNN_res", "vector<float>", &jet_cjetNN_res);
+    DYTree->Branch("jet_bJetNN_corr", "vector<float>", &jet_bJetNN_corr);
+    DYTree->Branch("jet_bJetNN_res", "vector<float>", &jet_bJetNN_res);
+    DYTree->Branch("jet_cJetNN_corr", "vector<float>", &jet_cJetNN_corr);
+    DYTree->Branch("jet_cJetNN_res", "vector<float>", &jet_cJetNN_res);
   }
   
   if(theStoreFatJetFlag){
@@ -3063,10 +3063,10 @@ void SKFlatMaker::fillJet(const edm::Event &iEvent)
     
     //BJetEnergyCorrectionNN
     unsigned index = jets_iter - jetHandle->begin();
-    jet_bjetNN_corr.push_back(bJetNNCorr_iter[index]);
-    jet_bjetNN_res.push_back(bJetNNRes_iter[index]);
-    jet_cjetNN_corr.push_back(cJetNNCorr_iter[index]);
-    jet_cjetNN_res.push_back(cJetNNRes_iter[index]);
+    jet_bJetNN_corr.push_back(bJetNNCorr_iter[index]);
+    jet_bJetNN_res.push_back(bJetNNRes_iter[index]);
+    jet_cJetNN_corr.push_back(cJetNNCorr_iter[index]);
+    jet_cJetNN_res.push_back(cJetNNRes_iter[index]);
     
     if(!IsData){
 

--- a/SKFlatMaker/test/RunSKFlatMaker.py
+++ b/SKFlatMaker/test/RunSKFlatMaker.py
@@ -320,7 +320,7 @@ if Is2016preVFP:
   #################
   bJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2016.pb")
   bJetNN.outputFormulas = cms.vstring(["at(0)*0.31976690888404846+1.047176718711853","0.5*(at(2)-at(1))*0.31976690888404846"])
-  cJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2016.pb")
+  cJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2016.pb")
   cJetNN.outputFormulas = cms.vstring(["at(0)*0.28862622380256653+0.9908722639083862","0.5*(at(2)-at(1))*0.28862622380256653"])
 
   #################
@@ -459,7 +459,7 @@ if Is2016postVFP:
   #################
   bJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2016.pb")
   bJetNN.outputFormulas = cms.vstring(["at(0)*0.31976690888404846+1.047176718711853","0.5*(at(2)-at(1))*0.31976690888404846"])
-  cJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2016.pb")
+  cJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2016.pb")
   cJetNN.outputFormulas = cms.vstring(["at(0)*0.28862622380256653+0.9908722639083862","0.5*(at(2)-at(1))*0.28862622380256653"])
 
   #################
@@ -599,7 +599,7 @@ elif Is2017:
   #################
   bJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2017.pb")
   bJetNN.outputFormulas = cms.vstring(["at(0)*0.28225210309028625+1.055067777633667","0.5*(at(2)-at(1))*0.28225210309028625"])
-  cJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2017.pb")
+  cJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2017.pb")
   cJetNN.outputFormulas = cms.vstring(["at(0)*0.24718524515628815+0.9927206635475159","0.5*(at(2)-at(1))*0.24718524515628815"])
 
   #################
@@ -663,7 +663,7 @@ elif Is2017:
   ## BJetEnergyRegression
   process.p *= process.bJetCorrSeq
 
-  #process.p *= process.recoTree
+  process.p *= process.recoTree
 
 elif Is2018:
 
@@ -732,6 +732,14 @@ elif Is2018:
   process.recoTree.AK4Jet_JER_SF_filepath    = cms.string('SKFlatMaker/SKFlatMaker/data/JRDatabase/textFiles/Summer19UL18_JRV2_MC/Summer19UL18_JRV2_MC_SF_AK4PFchs.txt')
   process.recoTree.AK8Jet_JER_PtRes_filepath = cms.string('SKFlatMaker/SKFlatMaker/data/JRDatabase/textFiles/Summer19UL18_JRV2_MC/Summer19UL18_JRV2_MC_PtResolution_AK8PFPuppi.txt')
   process.recoTree.AK8Jet_JER_SF_filepath    = cms.string('SKFlatMaker/SKFlatMaker/data/JRDatabase/textFiles/Summer19UL18_JRV2_MC/Summer19UL18_JRV2_MC_SF_AK8PFPuppi.txt')
+
+  #################
+  #### BJetEnergyRegression
+  #################
+  bJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/breg_training_2018.pb")
+  bJetNN.outputFormulas = cms.vstring(["at(0)*0.27912887930870056+1.0545977354049683","0.5*(at(2)-at(1))*0.27912887930870056"])
+  cJetNN.weightFile =  cms.FileInPath("PhysicsTools/NanoAOD/data/creg_training_2018.pb")
+  cJetNN.outputFormulas = cms.vstring(["at(0)*0.24325256049633026+0.993854820728302","0.5*(at(2)-at(1))*0.24325256049633026"])
 
   #################
   #### Update MET


### PR DESCRIPTION
* change c++ jet_bjetNN* -> jet_bJetNN* to be consistent with SKFlat branch names
* Use existing JEC jets for the bjet regression
* correct cjet regression file name
* uncomment recoTree process for 2017 (it was a mistake)