### PR TITLE
Electron L1 Et variable for the TnP

### DIFF
--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -44,7 +44,7 @@
 #include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
-
+#include "DataFormats/L1Trigger/interface/EGamma.h"
 
 ///////////////////
 // -- For MET -- //
@@ -229,6 +229,7 @@ class SKFlatMaker : public edm::EDAnalyzer
   edm::EDGetTokenT< double >                          RhoToken;
   edm::EDGetTokenT< std::vector<reco::Conversion> >   ConversionsToken;
   edm::EDGetTokenT< std::vector< reco::GsfTrack > >   GsfTrackToken;
+  edm::EDGetTokenT< BXVector<l1t::EGamma> >           L1EGToken;
   
   edm::EDGetTokenT< edm::TriggerResults >                          TriggerToken;
   edm::EDGetTokenT< edm::TriggerResults >                          TriggerTokenPAT;
@@ -556,6 +557,7 @@ class SKFlatMaker : public edm::EDAnalyzer
   vector<float> electron_hcalPFClusterIso;
   vector<ULong64_t> electron_pathbits;
   vector<ULong64_t> electron_filterbits;
+  vector<float> electron_l1et;
 
   //==== Muon
 


### PR DESCRIPTION
L1 Et threshold of electron dilepton triggers was sometimes higher than HLT, and it requires check L1 Et to measure the efficiency correctly.
* new branch: vector<float> electron_l1et (0.1% of total file size)