### PR TITLE
remove pfMET shifts

### DIFF
--- a/SKFlatMaker/interface/SKFlatMaker.h
+++ b/SKFlatMaker/interface/SKFlatMaker.h
@@ -756,9 +756,6 @@ class SKFlatMaker : public edm::EDAnalyzer
   float pfMET_Type1_PhiCor_pt;
   float pfMET_Type1_PhiCor_phi;
   float pfMET_Type1_PhiCor_SumEt;
-  vector<float> pfMET_pt_shifts;
-  vector<float> pfMET_phi_shifts;
-  vector<float> pfMET_SumEt_shifts;
   vector<float> pfMET_Type1_pt_shifts;
   vector<float> pfMET_Type1_phi_shifts;
   vector<float> pfMET_Type1_SumEt_shifts;

--- a/SKFlatMaker/script/VarList/varlist_MET.txt
+++ b/SKFlatMaker/script/VarList/varlist_MET.txt
@@ -7,9 +7,6 @@ float	pfMET_Type1_SumEt	0
 float	pfMET_Type1_PhiCor_pt	0
 float	pfMET_Type1_PhiCor_phi	0
 float	pfMET_Type1_PhiCor_SumEt	0
-float	pfMET_pt_shifts	1
-float	pfMET_phi_shifts	1
-float	pfMET_SumEt_shifts	1
 float	pfMET_Type1_pt_shifts	1
 float	pfMET_Type1_phi_shifts	1
 float	pfMET_Type1_SumEt_shifts	1

--- a/SKFlatMaker/src/SKFlatMaker.cc
+++ b/SKFlatMaker/src/SKFlatMaker.cc
@@ -255,9 +255,6 @@ void SKFlatMaker::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetu
   pfMET_Type1_PhiCor_pt=-999;
   pfMET_Type1_PhiCor_phi=-999;
   pfMET_Type1_PhiCor_SumEt=-999;
-  pfMET_pt_shifts.clear();
-  pfMET_phi_shifts.clear();
-  pfMET_SumEt_shifts.clear();
   pfMET_Type1_pt_shifts.clear();
   pfMET_Type1_phi_shifts.clear();
   pfMET_Type1_SumEt_shifts.clear();
@@ -1182,9 +1179,6 @@ void SKFlatMaker::beginJob()
     DYTree->Branch("pfMET_Type1_PhiCor_pt", &pfMET_Type1_PhiCor_pt, "pfMET_Type1_PhiCor_pt/F");
     DYTree->Branch("pfMET_Type1_PhiCor_phi", &pfMET_Type1_PhiCor_phi, "pfMET_Type1_PhiCor_phi/F");
     DYTree->Branch("pfMET_Type1_PhiCor_SumEt", &pfMET_Type1_PhiCor_SumEt, "pfMET_Type1_PhiCor_SumEt/F");
-    DYTree->Branch("pfMET_pt_shifts", "vector<float>", &pfMET_pt_shifts);
-    DYTree->Branch("pfMET_phi_shifts", "vector<float>", &pfMET_phi_shifts);
-    DYTree->Branch("pfMET_SumEt_shifts", "vector<float>", &pfMET_SumEt_shifts);
     DYTree->Branch("pfMET_Type1_pt_shifts", "vector<float>", &pfMET_Type1_pt_shifts);
     DYTree->Branch("pfMET_Type1_phi_shifts", "vector<float>", &pfMET_Type1_phi_shifts);
     DYTree->Branch("pfMET_Type1_SumEt_shifts", "vector<float>", &pfMET_Type1_SumEt_shifts);
@@ -2776,10 +2770,6 @@ void SKFlatMaker::fillMET(const edm::Event &iEvent)
   //==== https://github.com/cms-sw/cmssw/blob/4dbb008c8f4473dc9beb26171d7dde863880d02e/DataFormats/PatCandidates/interface/MET.h#L151-L157
 
   for(int i=0; i<pat::MET::METUncertaintySize; i++){
-
-    pfMET_pt_shifts.push_back( metHandle->front().shiftedPt(pat::MET::METUncertainty(i), pat::MET::Raw) );
-    pfMET_phi_shifts.push_back( metHandle->front().shiftedPhi(pat::MET::METUncertainty(i), pat::MET::Raw) );
-    pfMET_SumEt_shifts.push_back( metHandle->front().shiftedSumEt(pat::MET::METUncertainty(i), pat::MET::Raw) );
 
     pfMET_Type1_pt_shifts.push_back( metHandle->front().shiftedPt(pat::MET::METUncertainty(i), pat::MET::Type1) );
     pfMET_Type1_phi_shifts.push_back( metHandle->front().shiftedPhi(pat::MET::METUncertainty(i), pat::MET::Type1) );


### PR DESCRIPTION
As discussed in the lab meeting, removing pfmet shifts (without type1 correction). It will reduce the size of file about 2.8%.